### PR TITLE
Declare transitive no_std deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,13 @@ license = "MIT"
 edition = "2018"
 
 [features]
-default = ["alloc"]
+default = ["alloc", "ascii/std", "displaydoc/std"]
 alloc = []
 
 [dependencies]
-ascii = "1"
+ascii = { version = "1", default-features = false }
 enumn = "0.1"
-displaydoc = "0.2"
+displaydoc = { version = "0.2", default-features = false }
 
 [dev-dependencies]
 expect-test = "1"


### PR DESCRIPTION
Hi - i was trying to use this from no-std code and it seems like dependency features need to be explicitly spelled out to avoid pulling in transitive `std` deps in no-std build. Please have a look